### PR TITLE
Add ability to change hashed query strings even in a second pass

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ var plugin = function(manifest, options) {
 
     if (match) {
       if (options.verbose) gutil.log(PLUGIN_NAME, 'Found:', chalk.yellow(match[1].replace(/^\//, '')));
-      replace = manifest[match[1]] || manifest[match[1].replace(/^\//, '')];
+      replace = manifest[match[1]] || manifest[match[1].replace(/^\//, '')] || manifest[match[1].split('?')[0]];
       if (replace) line = line.replace(match[1], replace);
       if (options.verbose) gutil.log(PLUGIN_NAME, 'Replaced:', chalk.green(line));
     }

--- a/test/rev-qs-manifest.json
+++ b/test/rev-qs-manifest.json
@@ -1,0 +1,5 @@
+{
+  "images/favicon.ico": "images/favicon.ico?v=99999",
+  "js/site.js": "js/site.js?v=10923",
+  "js/other.js": "js/other.js?v=190283091"
+}

--- a/test/test-qs.js
+++ b/test/test-qs.js
@@ -1,0 +1,43 @@
+/* globals it*/
+'use strict';
+
+var assert = require('assert');
+var gutil = require('gulp-util');
+var fingerprint = require('../');
+var manifest = require('./rev-qs-manifest');
+var fakeFile = '<html>'
++ '<head>\n'
++ '<title>Some Web Site</title>\n'
++ '<link rel="shortcut icon" type="image/x-icon" href="images/favicon.ico?v=74180833826528598c89f0d4949473a7">\n'
++ '    <script src="js/site.js?v=c625c1e4b5dd80acb73126287946fd5b"></script>\n'
++ '   <script src="js/other.js"></script>\n'
++ '  </head>\n'
++ '  <body>\n'
++ '  </body>\n'
++ '</html>';
+
+it('should replace query string based fingerprints', function (done) {
+  var stream = fingerprint(manifest, {regex: /(?:href=|src=)"([^\"]*)"/});
+
+  stream.on('data', function (file) {
+    var updatedHTML = file.contents.toString();
+    console.log(updatedHTML);
+    var regex1 = /images\/favicon\.ico\?v=99999/;
+    var regex2 = /js\/site\.js\?v=10923/;
+    var regex3 = /js\/other\.js\?v=190283091/;
+    var match1 = regex1.exec(updatedHTML);
+    var match2 = regex2.exec(updatedHTML);
+    var match3 = regex3.exec(updatedHTML);
+
+    assert.equal(match1[0], 'images/favicon.ico?v=99999');
+    assert.equal(match2[0], 'js/site.js?v=10923');
+    assert.equal(match3[0], 'js/other.js?v=190283091');
+    done();
+  });
+
+  stream.write(new gutil.File({
+    path: 'app.html',
+    contents: new Buffer(fakeFile)
+  }));
+
+});


### PR DESCRIPTION
This may be a nice addition if you feel like it belongs to this plugin.
I'm using this plugin with a manifest that has query string parameters with the hashes, instead of file renames. I've found it useful to add the ability to override an existing query string parameter, so I don't have to keep a different source and destination for my cache-busted files.
This is similar to how other plugins work (like https://www.npmjs.org/package/gulp-rev-append). But I like gulp-fingerprint because is manifest-driven so it doesn't require to explicitly mark the urls I want to cache bust.
I've added a new test which hopefully shows what's the intended use.
