### PR TITLE
Support Sourcemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "chalk": "^0.4.0",
     "gulp-util": "^2.2.14",
     "split2": "^0.1.1",
-    "through2": "^0.4.2"
+    "through2": "^0.4.2",
+    "source-map": "~0.1.40"
   },
   "devDependencies": {
     "mocha": "^1.19.0"


### PR DESCRIPTION
I don't think this is ready to merge yet.
It seems to work for me, but I'm not a 100% sure I'm
- Generating the mappings correctly  
  Im computing the mapping for each start and end of a replacement. So, if `xxxoooxxx` were to be rewritten to `xxxpppppxxx`, the two mappings generated would be `3 -> 3` and `6 -> 8`.
  The first mapping doesn't seem to do anything here, but if there are multiple replacements on the same line, the mappings for the start of the replacements are accumulating the length differences of the preceding replacements.
- Applying the mappings correctly if there is already an existing sourcemap  
  `SourceMapGenerator#applySourceMap` seems pretty useless, since it results in only the mappings that I just generated, discarding any mappings from previous processing steps.
  Instead I branch off in case there is already a sourcemap present and generate mappings that have been prepared by `consumer.originalPositionFor`

The reason I wrote this was to preserve sourcemaps in this scenario:
1. Concatenate files
2. Minify
3. Run gulp-fingerprint

This seems stupid and it is, but for now it was easier for me to bring source map support to gulp-fingerprint than the rewrite my gulpfile.

So, the question is: Is there interest in having sourcemap support in gulp-fingerprint and is there anyone who can verify I'm generating the maps correctly
