### PR TITLE
fixed empty strings srcs

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ var plugin = function(manifest, options) {
     var line = buf.toString();
 
     line = line.replace(regex, function(str, i) {
-      var url = Array.prototype.slice.call(arguments, 1).filter(function(a) {return a;})[0];
+      var url = Array.prototype.slice.call(arguments, 1).filter(function(a) { return typeof a === 'string'; })[0];
       if (options.verbose) gutil.log(PLUGIN_NAME, 'Found:', chalk.yellow(url.replace(/^\//, '')));
       var replaced = manifest[url] || manifest[url.replace(/^\//, '')] || manifest[url.split(/[#?]/)[0]];
       if (!replaced && base) replaced = manifest[url.replace(baseRegex, '')];

--- a/test/test.js
+++ b/test/test.js
@@ -28,6 +28,7 @@ var fakeHtmlFile = '<body>\n' +
   '  <img src=\'/images/some-logo.png\' alt="" />\n' +
   '  <a href=/images/some-logo.png></a>\n' +
   '  <img src=/images/body-bg.jpg alt="" />\n' +
+  '  <img src="" alt="" />\n' +
   '</body>';
 
 ['regex', 'replace'].forEach(function(mode) {


### PR DESCRIPTION
There was a problem that made the plugin to break when trying to substitute an empty string match.